### PR TITLE
Add readSingleFrameFD method to MCP2517FD class and update VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "files.associations": {
         "locale": "cpp",
         "string": "cpp",
-        "cstdint": "cpp"
+        "cstdint": "cpp",
+        "memory": "cpp"
     }
 }

--- a/src/mcp2517fd.cpp
+++ b/src/mcp2517fd.cpp
@@ -1563,6 +1563,28 @@ void MCP2517FD::sendHandler(void)
         handleTXFifoISR(0); // if we have messages to send then try to queue them in the TX fifo
 }
 
+CAN_FRAME_FD MCP2517FD::readSingleFrameFD()
+{
+    CAN_FRAME_FD messageFD;
+    uint32_t ctrlVal;
+    uint32_t status;
+    uint16_t addr;
+
+    status = Read(ADDR_CiFIFOSTA + (CiFIFO_OFFSET * 1));
+    if (!(status & 1))
+    {
+        return messageFD;
+    }
+
+    // Get address to read from
+    addr = Read(ADDR_CiFIFOUA + (CiFIFO_OFFSET * 1));
+    // Then use that address to read the frame
+    ReadFrameBuffer(addr + 0x400, messageFD);  // stupidly the returned address from FIFOUA needs an offset
+    Write8(ADDR_CiFIFOCON + (CiFIFO_OFFSET * 1) + 1, 1); 
+
+    return messageFD;
+}
+
 //Not truly an interrupt handler in the sense that it does NOT run in interrupt context
 //but it does handle the MCP2517FD interrupt still.
 void MCP2517FD::intHandler(void) {

--- a/src/mcp2517fd.h
+++ b/src/mcp2517fd.h
@@ -93,6 +93,7 @@ class MCP2517FD : public CAN_COMMON
 	void txQueueSetup();
     void setRXBufferSize(int newSize);
     void setTXBufferSize(int newSize);
+	CAN_FRAME_FD readSingleFrameFD();
 
     QueueHandle_t callbackQueueMCP;
     TaskHandle_t intTaskFD = NULL;


### PR DESCRIPTION
This pull request includes changes to the `.vscode/settings.json` file and the `MCP2517FD` class in the `src/mcp2517fd.cpp` and `src/mcp2517fd.h` files. The changes enhance the functionality of the `MCP2517FD` class and update the VS Code settings for file associations.

Enhancements to `MCP2517FD` class:

* Added a new method `readSingleFrameFD` to the `MCP2517FD` class to read a single CAN FD frame. (`src/mcp2517fd.cpp`, `src/mcp2517fd.h`) [[1]](diffhunk://#diff-f66e20247167a7a011d2c5049e9cb2a7fa76a3924628c97ebb873e78bb46218eR1566-R1587) [[2]](diffhunk://#diff-0633f4c441e24048c178013c9bedcb3d4b86f9a58949a4d3c31186af1369b2c6R96)

VS Code settings update:

* Updated `.vscode/settings.json` to associate the `memory` file extension with `cpp`.